### PR TITLE
feat: add delay before response

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ mimicker(8080).routes(
 # The response will be: {"message": "Hello, JSON!"}
 ```
 
+#### Delaying the response
+
+This is useful when testing how your code handles timeouts when calling a web API.
+
+```python
+mimicker_server.routes(
+    get("/wait").
+    delay(0.5).
+    body("the client should have timed out")
+)
+try:
+    resp = requests.get("http://localhost:8080/wait", timeout=0.2)
+except requests.exceptions.ReadTimeout as error:
+    print(f"the API is unreachable due to error: {error=}")
+else:
+    # do things with the response
+    ...
+```
+
 #### Supporting Other Body Types (Text, Files, etc.)
 
 In addition to JSON bodies, Mimicker supports other types of content for the response body. Here's how you can return
@@ -204,6 +223,7 @@ mimicker(8080).routes(
 * `post(path)`: Defines a `POST` endpoint.
 * `put(path)`: Defines a `PUT` endpoint.
 * `delete(path)`: Defines a `DELETE` endpoint.
+* `.delay(duration)`: Defines the delay in seconds waited before returning the response (optional, 0. by default).
 * `.body(content)`: Defines the response `body`.
 * `.status(code)`: Defines the response `status code`.
 * `.headers(headers)`: Defines response `headers`.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ mimicker_server.routes(
 try:
     resp = requests.get("http://localhost:8080/wait", timeout=0.2)
 except requests.exceptions.ReadTimeout as error:
-    print(f"the API is unreachable due to error: {error=}")
+    print(f"the API is unreachable due to request timeout: {error=}")
 else:
     # do things with the response
     ...

--- a/mimicker/handler.py
+++ b/mimicker/handler.py
@@ -1,5 +1,6 @@
 import http.server
 import json
+from time import sleep
 from typing import Any, Tuple, Optional, Dict, Callable, List
 
 from mimicker.stub_group import StubGroup
@@ -36,11 +37,13 @@ class MimickerHandler(http.server.SimpleHTTPRequestHandler):
     def _send_response(
             self,
             matched_stub: Tuple[
-                int, Any, Optional[Callable], Optional[List[Tuple[str, str]]]
+                int, float, Any, Optional[Callable], Optional[List[Tuple[str, str]]]
             ],
             path_params: Dict[str, str]
     ):
-        status_code, response, response_func, headers = matched_stub
+        status_code, delay, response, response_func, headers = matched_stub
+        if delay > 0:
+            sleep(delay)
         if response_func:
             status_code, response = response_func()
 

--- a/mimicker/handler.py
+++ b/mimicker/handler.py
@@ -1,9 +1,9 @@
 import http.server
 import json
 from time import sleep
-from typing import Any, Tuple, Optional, Dict, Callable, List
+from typing import Any, Tuple, Optional, Dict, List
 
-from mimicker.stub_group import StubGroup
+from mimicker.stub_group import Stub, StubGroup
 
 
 class MimickerHandler(http.server.SimpleHTTPRequestHandler):
@@ -34,13 +34,7 @@ class MimickerHandler(http.server.SimpleHTTPRequestHandler):
         else:
             self._send_404_response(method)
 
-    def _send_response(
-            self,
-            matched_stub: Tuple[
-                int, float, Any, Optional[Callable], Optional[List[Tuple[str, str]]]
-            ],
-            path_params: Dict[str, str]
-    ):
+    def _send_response(self, matched_stub: Stub, path_params: Dict[str, str]):
         status_code, delay, response, response_func, headers = matched_stub
         if delay > 0:
             sleep(delay)

--- a/mimicker/route.py
+++ b/mimicker/route.py
@@ -8,7 +8,7 @@ class Route:
         self.method = method
         self.path = path
         self._body = {}
-        self._delay = 0
+        self._delay = 0.
         self._status = 200
         self._headers: List[Tuple[str, str]] = []
         self._response_func: Optional[Callable[[], Tuple[int, Any]]] = None

--- a/mimicker/route.py
+++ b/mimicker/route.py
@@ -8,6 +8,7 @@ class Route:
         self.method = method
         self.path = path
         self._body = {}
+        self._delay = 0
         self._status = 200
         self._headers: List[Tuple[str, str]] = []
         self._response_func: Optional[Callable[[], Tuple[int, Any]]] = None
@@ -16,6 +17,13 @@ class Route:
         parameterized_path = re.sub(r'\\{(\w+)\\}',
                                     r'(?P<\1>[^/]+)', escaped_path)
         self._compiled_path: Pattern = re.compile(f"^{parameterized_path}$")
+
+    def delay(self, delay: float):
+        """
+        Sets the delay (in seconds) to wait before returning the response
+        """
+        self._delay = delay
+        return self
 
     def body(self, response: Union[Dict[str, Any], str] = None):
         self._body = response if response is not None else ""
@@ -38,6 +46,7 @@ class Route:
             "method": self.method,
             "path": self.path,
             "compiled_path": self._compiled_path,
+            "delay": self._delay,
             "body": self._body,
             "status": self._status,
             "headers": self._headers,

--- a/mimicker/server.py
+++ b/mimicker/server.py
@@ -7,11 +7,13 @@ from mimicker.handler import MimickerHandler
 from mimicker.route import Route
 from mimicker.stub_group import StubGroup
 
+class ReusableAddressTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
 
 class MimickerServer:
     def __init__(self, port: int = 8080):
         self.stub_matcher = StubGroup()
-        self.server = socketserver.TCPServer(("", port), self._handler_factory)
+        self.server = ReusableAddressTCPServer(("", port), self._handler_factory)
         self._thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         atexit.register(self.shutdown)
 

--- a/mimicker/server.py
+++ b/mimicker/server.py
@@ -25,6 +25,7 @@ class MimickerServer:
                 method=route_config["method"],
                 pattern=route_config["compiled_path"],
                 status_code=route_config["status"],
+                delay=route_config["delay"],
                 response=route_config["body"],
                 headers=route_config["headers"],
                 response_func=route_config["response_func"]

--- a/mimicker/server.py
+++ b/mimicker/server.py
@@ -7,13 +7,13 @@ from mimicker.handler import MimickerHandler
 from mimicker.route import Route
 from mimicker.stub_group import StubGroup
 
-class ReusableAddressTCPServer(socketserver.TCPServer):
+class ReusableAddressThreadingTCPServer(socketserver.ThreadingTCPServer):
     allow_reuse_address = True
 
 class MimickerServer:
     def __init__(self, port: int = 8080):
         self.stub_matcher = StubGroup()
-        self.server = ReusableAddressTCPServer(("", port), self._handler_factory)
+        self.server = ReusableAddressThreadingTCPServer(("", port), self._handler_factory)
         self._thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         atexit.register(self.shutdown)
 
@@ -41,6 +41,7 @@ class MimickerServer:
         return self
 
     def shutdown(self):
+        self.server.server_close()
         self.server.shutdown()
         if self._thread.is_alive():
             self._thread.join()

--- a/mimicker/stub_group.py
+++ b/mimicker/stub_group.py
@@ -8,12 +8,12 @@ class StubGroup:
             str,
             Dict[
                 Pattern,
-                Tuple[int, Any, Optional[Callable], Optional[List[Tuple[str, str]]]]
+                Tuple[int, float, Any, Optional[Callable], Optional[List[Tuple[str, str]]]]
             ]
         ] = {}
 
     def add(self, method: str, pattern: Union[str, Pattern],
-            status_code: int, response: Any,
+            status_code: int, response: Any, delay: Optional[float] = 0,
             response_func: Optional[Callable[[], Tuple[int, Any]]] = None,
             headers: Optional[List[Tuple[str, str]]] = None):
         if method not in self.stubs:
@@ -23,14 +23,14 @@ class StubGroup:
             substituted_pattern = re.sub(r'\{(\w+)\}', r'(?P<\1>[^/]+)', pattern)
             pattern = re.compile(f"^{substituted_pattern}$")
 
-        self.stubs[method][pattern] = (status_code, response, response_func, headers)
+        self.stubs[method][pattern] = (status_code, delay, response, response_func, headers)
 
     def match(self, method: str, path: str,
               request_headers: Optional[Dict[str, str]] = None):
         matched_stub = None
         path_params = {}
 
-        for compiled_path, (status_code, response, response_func, headers) \
+        for compiled_path, (status_code, delay, response, response_func, headers) \
                 in self.stubs.get(method, {}).items():
             match = compiled_path.match(path)
             if match:
@@ -45,7 +45,7 @@ class StubGroup:
                 if headers and not headers_included:
                     pass
 
-                matched_stub = (status_code, response, response_func, headers)
+                matched_stub = (status_code, delay, response, response_func, headers)
                 path_params = match.groupdict()
                 break
 

--- a/mimicker/stub_group.py
+++ b/mimicker/stub_group.py
@@ -20,8 +20,8 @@ class StubGroup:
             self.stubs[method] = {}
 
         if isinstance(pattern, str):
-            pattern = re.compile(f"^{re.sub(r'\\{(\\w+)\\}',
-                                            r'(?P<\\1>[^/]+)', pattern)}$")
+            substituted_pattern = re.sub(r'\{(\w+)\}', r'(?P<\1>[^/]+)', pattern)
+            pattern = re.compile(f"^{substituted_pattern}$")
 
         self.stubs[method][pattern] = (status_code, response, response_func, headers)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,11 @@ homepage = "https://github.com/amaziahub/mimicker"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-requests = "^2.0"
-
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"
 PyHamcrest = "^2.0"
+requests = "^2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest-cov = "<3.0"

--- a/tests/support/client.py
+++ b/tests/support/client.py
@@ -9,33 +9,33 @@ class Client:
     def get(self, path, headers=None, **kwargs):
         return requests.get(f"{self.root + path}", headers=headers, **kwargs)
 
-    def post_as_json(self, path, body=None, headers=None):
-        return requests.post(f"{self.root + path}", json=body, headers=headers)
+    def post_as_json(self, path, body=None, headers=None, **kwargs):
+        return requests.post(f"{self.root + path}", json=body, headers=headers, **kwargs)
 
-    def post_as_text(self, path, body=None, headers=None):
+    def post_as_text(self, path, body=None, headers=None, **kwargs):
         headers = headers or {}
         headers['Content-Type'] = 'text/plain'
-        return requests.post(f"{self.root + path}", data=body, headers=headers)
+        return requests.post(f"{self.root + path}", data=body, headers=headers, **kwargs)
 
-    def post_as_image(self, path, body=None, headers=None):
+    def post_as_image(self, path, body=None, headers=None, **kwargs):
         headers = headers or {}
         headers['Content-Type'] = 'image/png'
-        return requests.post(f"{self.root + path}", data=body, headers=headers)
+        return requests.post(f"{self.root + path}", data=body, headers=headers, **kwargs)
 
-    def post_as_file(self, path, body=None, headers=None):
-        return requests.post(f"{self.root + path}", files=body, headers=headers)
+    def post_as_file(self, path, body=None, headers=None, **kwargs):
+        return requests.post(f"{self.root + path}", files=body, headers=headers, **kwargs)
 
-    def put_as_json(self, path, body=None, headers=None):
-        return requests.put(f"{self.root + path}", json=body, headers=headers)
+    def put_as_json(self, path, body=None, headers=None, **kwargs):
+        return requests.put(f"{self.root + path}", json=body, headers=headers, **kwargs)
 
-    def put_as_text(self, path, body=None, headers=None):
-        return requests.put(f"{self.root + path}", data=body, headers=headers)
+    def put_as_text(self, path, body=None, headers=None, **kwargs):
+        return requests.put(f"{self.root + path}", data=body, headers=headers, **kwargs)
 
-    def put_as_file(self, path, body=None, headers=None):
-        return requests.put(f"{self.root + path}", files=body, headers=headers)
+    def put_as_file(self, path, body=None, headers=None, **kwargs):
+        return requests.put(f"{self.root + path}", files=body, headers=headers, **kwargs)
 
-    def put(self, path, body=None, headers=None):
-        return requests.put(f"{self.root + path}", json=body, headers=headers)
+    def put(self, path, body=None, headers=None, **kwargs):
+        return requests.put(f"{self.root + path}", json=body, headers=headers, **kwargs)
 
-    def delete(self, path, headers=None):
-        return requests.delete(f"{self.root + path}", headers=headers)
+    def delete(self, path, headers=None, **kwargs):
+        return requests.delete(f"{self.root + path}", headers=headers, **kwargs)

--- a/tests/support/client.py
+++ b/tests/support/client.py
@@ -6,8 +6,8 @@ class Client:
     def __init__(self, root='http://localhost:8080'):
         self.root = root
 
-    def get(self, path, headers=None):
-        return requests.get(f"{self.root + path}", headers=headers)
+    def get(self, path, headers=None, **kwargs):
+        return requests.get(f"{self.root + path}", headers=headers, **kwargs)
 
     def post_as_json(self, path, body=None, headers=None):
         return requests.post(f"{self.root + path}", json=body, headers=headers)

--- a/tests/test_mimicker_get.py
+++ b/tests/test_mimicker_get.py
@@ -1,4 +1,11 @@
+from time import perf_counter
+from requests.exceptions import ReadTimeout
+
 from hamcrest import assert_that, is_, has_entry, equal_to
+from hamcrest.library.number.ordering_comparison import greater_than_or_equal_to
+from hamcrest.library.number.iscloseto import close_to
+
+from pytest import mark, raises
 
 from mimicker.mimicker import get
 from tests.support.client import Client
@@ -79,3 +86,35 @@ def test_get_headers(mimicker_server):
     )
     resp = Client().get('/hello', {"Content-Type": "application/json"})
     assert_that(resp.status_code, is_(200))
+
+@mark.parametrize(
+    "delay_in_seconds",
+    [0.1, 0.2, 0.5],
+)
+def test_get_with_delay(mimicker_server, delay_in_seconds: float):
+    mimicker_server.routes(
+        get("/wait").
+        delay(delay_in_seconds).
+        body("finally here")
+    )
+
+    start = perf_counter()
+    resp = Client().get('/wait')
+    duration_seconds = perf_counter() - start
+
+    assert_that(resp.status_code, is_(200))
+    assert_that(resp.text, is_("finally here"))
+    assert_that(duration_seconds, is_(greater_than_or_equal_to(delay_in_seconds)))
+    assert_that(duration_seconds, is_(close_to(delay_in_seconds, 0.05)))
+
+def test_get_with_timedout_delay(mimicker_server):
+    mimicker_server.routes(
+        get("/wait").
+        delay(0.1).
+        body("finally here")
+    )
+
+    with raises(ReadTimeout) as error:
+        Client().get('/wait', timeout=0.05)
+
+    assert_that(str(error.value), is_("HTTPConnectionPool(host='localhost', port=8080): Read timed out. (read timeout=0.05)"))

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -7,6 +7,7 @@ def test_route_initialization():
     route = Route("GET", "/hello")
     assert_that(route.method, equal_to("GET"))
     assert_that(route.path, equal_to("/hello"))
+    assert_that(route._delay, equal_to(0))
     assert_that(route._status, equal_to(200))
     assert_that(route._body, equal_to({}))
 
@@ -30,12 +31,14 @@ def test_route_with_path_parameter():
 
 def test_route_build():
     route = (Route("GET", "/hello/{greet}")
+             .delay(2)
              .body({"message": "Hello, {greet}!"})
              .status(201))
     route_config = route.build()
 
     assert_that(route_config["method"], equal_to("GET"))
     assert_that(route_config["path"], equal_to("/hello/{greet}"))
+    assert_that(route_config["delay"], equal_to(2))
     assert_that(route_config["status"], equal_to(201))
     assert_that(route_config["body"], equal_to({"message": "Hello, {greet}!"}))
     assert_that(route_config["compiled_path"], instance_of(re.Pattern))

--- a/tests/test_stub_group.py
+++ b/tests/test_stub_group.py
@@ -20,7 +20,7 @@ def test_match():
     stub_group = StubGroup()
     stub_group.add("GET", "/hi", 200, {"message": "hello"})
     matched, _ = stub_group.match("GET", "/hi")
-    assert_that(matched, is_((200, 0, {"message": "hello"}, None, None)))
+    assert_that(matched, is_((200, 0., {"message": "hello"}, None, None)))
 
 
 def test_none_on_partial_match():
@@ -39,16 +39,16 @@ def test_match_w_path_param():
 
     matched, path_param = stub_group.match("GET", "/hello/mimicker")
 
-    assert_that(matched, is_((200, 0, {"message": "Hello, {name}!"}, None, None)))
+    assert_that(matched, is_((200, 0., {"message": "Hello, {name}!"}, None, None)))
     assert_that(path_param, is_({"name": "mimicker"}))
 
 def test_match_w_delay():
     stub_group = StubGroup()
-    stub_group.add("GET", "/hi", 200, {"message": "hello"}, delay=3)
+    stub_group.add("GET", "/hi", 200, {"message": "hello"}, delay=3.)
 
     matched, _ = stub_group.match("GET", "/hi")
 
-    assert_that(matched, is_((200, 3, {"message": "hello"}, None, None)))
+    assert_that(matched, is_((200, 3., {"message": "hello"}, None, None)))
 
 
 def test_match_stub_with_response_func():
@@ -60,7 +60,7 @@ def test_match_stub_with_response_func():
     stub_group.add("GET", r"^/dynamic$",
                    200, {}, response_func=dynamic_response)
     matched, _ = stub_group.match("GET", "/dynamic")
-    assert_that(matched, is_((200, 0, {}, dynamic_response, None)))
+    assert_that(matched, is_((200, 0., {}, dynamic_response, None)))
 
 
 def test_match_given_unexpected_header():
@@ -71,7 +71,7 @@ def test_match_given_unexpected_header():
     matched, _ = stub_group.match(
         "GET", "/hi",
         request_headers={"Content-Type": "application/json"})
-    assert_that(matched, is_((200, 0, {'message': 'hello'}, None,
+    assert_that(matched, is_((200, 0., {'message': 'hello'}, None,
                               [('Content-Type', 'text/plain')])))
 
 
@@ -87,7 +87,7 @@ def test_match_given_partial_expected_headers():
     matched, _ = stub_group.match(
         "GET", "/hi",
         request_headers={"Content-Type": "application/json"})
-    assert_that(matched, is_((200, 0, {'message': 'hello'},
+    assert_that(matched, is_((200, 0., {'message': 'hello'},
                               None, [
                                   ('Content-Type', 'application/json'),
                                   ('Authorization', 'Bearer YOUR_TOKEN'),

--- a/tests/test_stub_group.py
+++ b/tests/test_stub_group.py
@@ -20,7 +20,7 @@ def test_match():
     stub_group = StubGroup()
     stub_group.add("GET", "/hi", 200, {"message": "hello"})
     matched, _ = stub_group.match("GET", "/hi")
-    assert_that(matched, is_((200, {"message": "hello"}, None, None)))
+    assert_that(matched, is_((200, 0, {"message": "hello"}, None, None)))
 
 
 def test_none_on_partial_match():
@@ -39,8 +39,16 @@ def test_match_w_path_param():
 
     matched, path_param = stub_group.match("GET", "/hello/mimicker")
 
-    assert_that(matched, is_((200, {"message": "Hello, {name}!"}, None, None)))
+    assert_that(matched, is_((200, 0, {"message": "Hello, {name}!"}, None, None)))
     assert_that(path_param, is_({"name": "mimicker"}))
+
+def test_match_w_delay():
+    stub_group = StubGroup()
+    stub_group.add("GET", "/hi", 200, {"message": "hello"}, delay=3)
+
+    matched, _ = stub_group.match("GET", "/hi")
+
+    assert_that(matched, is_((200, 3, {"message": "hello"}, None, None)))
 
 
 def test_match_stub_with_response_func():
@@ -52,7 +60,7 @@ def test_match_stub_with_response_func():
     stub_group.add("GET", r"^/dynamic$",
                    200, {}, response_func=dynamic_response)
     matched, _ = stub_group.match("GET", "/dynamic")
-    assert_that(matched, is_((200, {}, dynamic_response, None)))
+    assert_that(matched, is_((200, 0, {}, dynamic_response, None)))
 
 
 def test_match_given_unexpected_header():
@@ -63,7 +71,7 @@ def test_match_given_unexpected_header():
     matched, _ = stub_group.match(
         "GET", "/hi",
         request_headers={"Content-Type": "application/json"})
-    assert_that(matched, is_((200, {'message': 'hello'}, None,
+    assert_that(matched, is_((200, 0, {'message': 'hello'}, None,
                               [('Content-Type', 'text/plain')])))
 
 
@@ -79,7 +87,7 @@ def test_match_given_partial_expected_headers():
     matched, _ = stub_group.match(
         "GET", "/hi",
         request_headers={"Content-Type": "application/json"})
-    assert_that(matched, is_((200, {'message': 'hello'},
+    assert_that(matched, is_((200, 0, {'message': 'hello'},
                               None, [
                                   ('Content-Type', 'application/json'),
                                   ('Authorization', 'Bearer YOUR_TOKEN'),


### PR DESCRIPTION
hello @amaziahub, thank you for the mimicker project :pray: 

Here is a pull request to add the `route.delay(duration)` optional feature to make a matched stub delay before returning the response. This feature allows to test how the code (calling a mimicked web API) reacts to a connection timeout.

I added:
- some documentation in the README.md file
- some unit tests about the route definition and to check that the mimicker server actually waits when asked to

This feature and the tests are included in the same commit. Other commits are suggestions that can be reverted if you like:
- I moved requests in the dev dependencies because it is not used in the production code: it thus won't be installed in the codebases using mimicker (requests can conflict with other web clients like niquests or httpx)
- I made mimicker able to run several times in a row so that tests can be run multiple times
- I created a namedtuple class to model a `Stub` to increase code legibility and add type annotations in the code

Also, the first commit was necessary to fix some syntax errors in an f-string.

I tried to follow the code standards of the project and I used hamcrest in the unit tests (thanks for the discovery), I hope you will appreciate this contribution. Thank you again for mimicker :slightly_smiling_face: 